### PR TITLE
Removed Google+ link from contact info because Google+ was shut down …

### DIFF
--- a/components/contact-info.vue
+++ b/components/contact-info.vue
@@ -46,11 +46,6 @@ module.exports = {
           external: true
         },
         {
-          name: 'Google+',
-          url: 'https://plus.google.com/u/0/118221338592889901873',
-          external: true
-        },
-        {
           name: 'Instagram',
           url: 'https://www.instagram.com/explore/tags/colesheartart/',
           external: true


### PR DESCRIPTION
Google+ was shut down in April 2019. [https://en.wikipedia.org/wiki/Google%2B#Shutdown_of_consumer_version](url)